### PR TITLE
fix: 将 videoDuration 参数改为 durationSeconds

### DIFF
--- a/video_generator.py
+++ b/video_generator.py
@@ -72,7 +72,7 @@ class VideoGenerator:
         payload = {
             "instances": instances,
             "parameters": {
-                "videoDuration": duration,
+                "durationSeconds": duration,
                 "sampleCount": 1,
                 "aspectRatio": aspect_ratio,
                 "generateAudio": True,


### PR DESCRIPTION
Generated with [codeagent](https://github.com/qbox/codeagent)