### PR TITLE
修复 Gradle 配置错误

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,13 +11,6 @@ buildscript {
     }
 }
 
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-    }
-}
-
 task clean(type: Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
删除 build.gradle 中的 allprojects 仓库配置块，
因为 settings.gradle 已设置 FAIL_ON_PROJECT_REPOS 模式，
要求所有仓库在 settings.gradle 中统一管理。

Generated with [codeagent](https://github.com/qbox/codeagent)