### PR TITLE
feat: 重构Android手机竖屏界面为Tab导航

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -57,8 +57,20 @@ dependencies {
     implementation 'com.google.android.material:material:1.11.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     
+    // ViewPager2
+    implementation 'androidx.viewpager2:viewpager2:1.0.0'
+    
+    // RecyclerView
+    implementation 'androidx.recyclerview:recyclerview:1.3.2'
+    
+    // CardView
+    implementation 'androidx.cardview:cardview:1.0.0'
+    
     // WebView 相关
     implementation 'androidx.webkit:webkit:1.9.0'
+    
+    // Coroutines
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
     
     // 测试依赖
     testImplementation 'junit:junit:4.13.2'

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -36,6 +36,12 @@
             </intent-filter>
         </activity>
         
+        <activity
+            android:name=".SettingsActivity"
+            android:exported="false"
+            android:configChanges="orientation|screenSize|keyboardHidden"
+            android:windowSoftInputMode="adjustResize" />
+        
         <!-- FileProvider for file sharing -->
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/android/app/src/main/java/com/novelanime/app/MainActivity.kt
+++ b/android/app/src/main/java/com/novelanime/app/MainActivity.kt
@@ -1,152 +1,54 @@
 package com.novelanime.app
 
 import android.Manifest
-import android.app.Activity
-import android.content.Intent
 import android.content.pm.PackageManager
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
-import android.webkit.*
 import android.widget.Toast
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.viewpager2.widget.ViewPager2
+import com.google.android.material.tabs.TabLayout
+import com.google.android.material.tabs.TabLayoutMediator
 
 class MainActivity : AppCompatActivity() {
 
-    private lateinit var webView: WebView
-    private var fileUploadCallback: ValueCallback<Array<Uri>>? = null
-    private val FILE_CHOOSER_REQUEST_CODE = 1001
+    private lateinit var viewPager: ViewPager2
+    private lateinit var tabLayout: TabLayout
     private val PERMISSION_REQUEST_CODE = 1002
 
-    // 配置你的 Flask 服务器地址
-    // 如果在同一设备上运行服务器，使用 localhost
-    // 如果在局域网其他设备上，使用该设备的 IP 地址
-    private val SERVER_URL = "http://n2v.qbox.net"
-    // private val SERVER_URL = "http://10.0.2.2:5000"  // Android 模拟器访问主机的特殊地址
-    // private val SERVER_URL = "http://192.168.1.100:5000"  // 替换为你的实际 IP 地址
+    companion object {
+        const val SERVER_URL = "http://n2v.qbox.net"
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        webView = findViewById(R.id.webview)
-        setupWebView()
+        viewPager = findViewById(R.id.viewPager)
+        tabLayout = findViewById(R.id.tabLayout)
+        
+        setupViewPager()
         checkPermissions()
     }
 
-    private fun setupWebView() {
-        webView.settings.apply {
-            javaScriptEnabled = true
-            domStorageEnabled = true
-            allowFileAccess = true
-            allowContentAccess = true
-            mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
-            
-            // 启用缩放
-            setSupportZoom(true)
-            builtInZoomControls = true
-            displayZoomControls = false
-            
-            // 设置用户代理
-            userAgentString = userAgentString + " NovelAnimeApp/1.0"
-            
-            // 缓存设置
-            cacheMode = WebSettings.LOAD_DEFAULT
-            databaseEnabled = true
-        }
-
-        // WebViewClient - 处理页面导航
-        webView.webViewClient = object : WebViewClient() {
-            override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
-                return false
-            }
-
-            override fun onPageFinished(view: WebView?, url: String?) {
-                super.onPageFinished(view, url)
-                // 注入 JavaScript 来处理文件上传
-                injectFileUploadHandler()
-            }
-
-            override fun onReceivedError(view: WebView?, request: WebResourceRequest?, error: WebResourceError?) {
-                super.onReceivedError(view, request, error)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                    showConnectionError(error?.description?.toString() ?: "连接错误")
-                }
-            }
-        }
-
-        // WebChromeClient - 处理文件上传和其他功能
-        webView.webChromeClient = object : WebChromeClient() {
-            override fun onShowFileChooser(
-                webView: WebView?,
-                filePathCallback: ValueCallback<Array<Uri>>?,
-                fileChooserParams: FileChooserParams?
-            ): Boolean {
-                fileUploadCallback?.onReceiveValue(null)
-                fileUploadCallback = filePathCallback
-
-                val intent = Intent(Intent.ACTION_GET_CONTENT).apply {
-                    type = "text/plain"
-                    addCategory(Intent.CATEGORY_OPENABLE)
-                }
-
-                try {
-                    startActivityForResult(
-                        Intent.createChooser(intent, "选择小说文件"),
-                        FILE_CHOOSER_REQUEST_CODE
-                    )
-                } catch (e: Exception) {
-                    fileUploadCallback = null
-                    Toast.makeText(this@MainActivity, "无法打开文件选择器", Toast.LENGTH_SHORT).show()
-                    return false
-                }
-
-                return true
-            }
-
-            override fun onConsoleMessage(consoleMessage: ConsoleMessage?): Boolean {
-                // 用于调试 WebView 中的 JavaScript 错误
-                consoleMessage?.let {
-                    android.util.Log.d("WebView", "${it.message()} -- From line ${it.lineNumber()} of ${it.sourceId()}")
-                }
-                return true
-            }
-
-            override fun onProgressChanged(view: WebView?, newProgress: Int) {
-                super.onProgressChanged(view, newProgress)
-                // 可以在这里添加加载进度条
-            }
-        }
-
-        // 加载主页
-        loadServerUrl()
+    private fun setupViewPager() {
+        val adapter = ViewPagerAdapter(this)
+        viewPager.adapter = adapter
+        
+        val tabTitles = listOf("广布广场", "动漫播放", "配置")
+        TabLayoutMediator(tabLayout, viewPager) { tab, position ->
+            tab.text = tabTitles[position]
+        }.attach()
+        
+        viewPager.currentItem = 0
     }
 
-    private fun loadServerUrl() {
-        webView.loadUrl(SERVER_URL)
-    }
-
-    private fun injectFileUploadHandler() {
-        // 注入 JavaScript 来增强文件上传体验
-        val js = """
-            (function() {
-                // 可以在这里添加自定义的 JavaScript 代码
-                console.log('NovelAnime Android App initialized');
-            })();
-        """.trimIndent()
-        webView.evaluateJavascript(js, null)
-    }
-
-    private fun showConnectionError(error: String) {
-        AlertDialog.Builder(this)
-            .setTitle("连接错误")
-            .setMessage("无法连接到服务器。请确保：\n\n1. Flask 服务器正在运行\n2. 服务器地址配置正确\n3. 设备已连接到网络\n\n错误信息: $error")
-            .setPositiveButton("重试") { _, _ -> loadServerUrl() }
-            .setNegativeButton("退出") { _, _ -> finish() }
-            .show()
+    fun loadRecordInPlayer(sessionId: String) {
+        viewPager.currentItem = 1
+        val fragment = supportFragmentManager.findFragmentByTag("f1") as? PlayerFragment
+        fragment?.loadRecord(sessionId)
     }
 
     private fun checkPermissions() {
@@ -190,30 +92,11 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
-        super.onActivityResult(requestCode, resultCode, data)
-        
-        if (requestCode == FILE_CHOOSER_REQUEST_CODE) {
-            if (resultCode == Activity.RESULT_OK && data != null) {
-                val uri = data.data
-                fileUploadCallback?.onReceiveValue(arrayOf(uri!!))
-            } else {
-                fileUploadCallback?.onReceiveValue(null)
-            }
-            fileUploadCallback = null
-        }
-    }
-
     override fun onBackPressed() {
-        if (webView.canGoBack()) {
-            webView.goBack()
+        if (viewPager.currentItem > 0) {
+            viewPager.currentItem = 0
         } else {
             super.onBackPressed()
         }
-    }
-
-    override fun onDestroy() {
-        webView.destroy()
-        super.onDestroy()
     }
 }

--- a/android/app/src/main/java/com/novelanime/app/PlayerFragment.kt
+++ b/android/app/src/main/java/com/novelanime/app/PlayerFragment.kt
@@ -1,0 +1,51 @@
+package com.novelanime.app
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.fragment.app.Fragment
+
+class PlayerFragment : Fragment() {
+
+    private lateinit var webView: WebView
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_player, container, false)
+        
+        webView = view.findViewById(R.id.playerWebView)
+        setupWebView()
+        
+        return view
+    }
+
+    private fun setupWebView() {
+        webView.settings.apply {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+            allowFileAccess = true
+            allowContentAccess = true
+            mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+            cacheMode = WebSettings.LOAD_DEFAULT
+        }
+
+        webView.webViewClient = WebViewClient()
+        webView.loadUrl("${MainActivity.SERVER_URL}/home")
+    }
+
+    fun loadRecord(sessionId: String) {
+        webView.loadUrl("${MainActivity.SERVER_URL}/home?session_id=$sessionId")
+    }
+
+    override fun onDestroy() {
+        webView.destroy()
+        super.onDestroy()
+    }
+}

--- a/android/app/src/main/java/com/novelanime/app/SettingsActivity.kt
+++ b/android/app/src/main/java/com/novelanime/app/SettingsActivity.kt
@@ -1,0 +1,47 @@
+package com.novelanime.app
+
+import android.os.Bundle
+import android.webkit.WebSettings
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.appcompat.app.AppCompatActivity
+
+class SettingsActivity : AppCompatActivity() {
+
+    private lateinit var webView: WebView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        
+        webView = WebView(this)
+        setContentView(webView)
+        
+        setupWebView()
+        webView.loadUrl("${MainActivity.SERVER_URL}/settings")
+    }
+
+    private fun setupWebView() {
+        webView.settings.apply {
+            javaScriptEnabled = true
+            domStorageEnabled = true
+            allowFileAccess = true
+            allowContentAccess = true
+            mixedContentMode = WebSettings.MIXED_CONTENT_ALWAYS_ALLOW
+        }
+
+        webView.webViewClient = WebViewClient()
+    }
+
+    override fun onBackPressed() {
+        if (webView.canGoBack()) {
+            webView.goBack()
+        } else {
+            super.onBackPressed()
+        }
+    }
+
+    override fun onDestroy() {
+        webView.destroy()
+        super.onDestroy()
+    }
+}

--- a/android/app/src/main/java/com/novelanime/app/SettingsFragment.kt
+++ b/android/app/src/main/java/com/novelanime/app/SettingsFragment.kt
@@ -1,0 +1,64 @@
+package com.novelanime.app
+
+import android.content.Intent
+import android.graphics.BitmapFactory
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import kotlinx.coroutines.*
+import java.net.HttpURLConnection
+import java.net.URL
+
+class SettingsFragment : Fragment() {
+
+    private val scope = CoroutineScope(Dispatchers.Main + Job())
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_settings, container, false)
+        
+        val btnSettings = view.findViewById<Button>(R.id.btnSettings)
+        val wechatQRCode = view.findViewById<ImageView>(R.id.wechatQRCode)
+        val apkQRCode = view.findViewById<ImageView>(R.id.apkQRCode)
+        
+        btnSettings.setOnClickListener {
+            val intent = Intent(activity, SettingsActivity::class.java)
+            startActivity(intent)
+        }
+        
+        loadQRCode(wechatQRCode, "${MainActivity.SERVER_URL}/static/qrcode.png")
+        loadQRCode(apkQRCode, "${MainActivity.SERVER_URL}/static/apk_qr.png")
+        
+        return view
+    }
+
+    private fun loadQRCode(imageView: ImageView, url: String) {
+        scope.launch {
+            try {
+                val bitmap = withContext(Dispatchers.IO) {
+                    val connection = URL(url).openConnection() as HttpURLConnection
+                    connection.doInput = true
+                    connection.connect()
+                    val input = connection.inputStream
+                    BitmapFactory.decodeStream(input)
+                }
+                imageView.setImageBitmap(bitmap)
+            } catch (e: Exception) {
+                Toast.makeText(context, "加载二维码失败", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
+    }
+}

--- a/android/app/src/main/java/com/novelanime/app/SharedRecordsAdapter.kt
+++ b/android/app/src/main/java/com/novelanime/app/SharedRecordsAdapter.kt
@@ -1,0 +1,53 @@
+package com.novelanime.app
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+
+class SharedRecordsAdapter(
+    private val onItemClick: (SharedRecord) -> Unit
+) : RecyclerView.Adapter<SharedRecordsAdapter.ViewHolder>() {
+
+    private var records = listOf<SharedRecord>()
+
+    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val tvFilename: TextView = view.findViewById(R.id.tvFilename)
+        val tvUsername: TextView = view.findViewById(R.id.tvUsername)
+        val tvTimestamp: TextView = view.findViewById(R.id.tvTimestamp)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_shared_record, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val record = records[position]
+        holder.tvFilename.text = record.filename
+        holder.tvUsername.text = "作者: ${record.username}"
+        holder.tvTimestamp.text = formatTimestamp(record.timestamp)
+        
+        holder.itemView.setOnClickListener {
+            onItemClick(record)
+        }
+    }
+
+    override fun getItemCount() = records.size
+
+    fun updateRecords(newRecords: List<SharedRecord>) {
+        records = newRecords
+        notifyDataSetChanged()
+    }
+
+    private fun formatTimestamp(timestamp: String): String {
+        if (timestamp.isEmpty()) return ""
+        return try {
+            timestamp.substring(0, 16).replace("T", " ")
+        } catch (e: Exception) {
+            timestamp
+        }
+    }
+}

--- a/android/app/src/main/java/com/novelanime/app/SquareFragment.kt
+++ b/android/app/src/main/java/com/novelanime/app/SquareFragment.kt
@@ -1,0 +1,106 @@
+package com.novelanime.app
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.*
+import org.json.JSONObject
+import java.net.HttpURLConnection
+import java.net.URL
+
+class SquareFragment : Fragment() {
+
+    private lateinit var recyclerView: RecyclerView
+    private lateinit var adapter: SharedRecordsAdapter
+    private val scope = CoroutineScope(Dispatchers.Main + Job())
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_square, container, false)
+        
+        recyclerView = view.findViewById(R.id.recyclerView)
+        recyclerView.layoutManager = LinearLayoutManager(context)
+        
+        adapter = SharedRecordsAdapter { record ->
+            onRecordClicked(record)
+        }
+        recyclerView.adapter = adapter
+        
+        loadSharedRecords()
+        
+        return view
+    }
+
+    private fun loadSharedRecords() {
+        scope.launch {
+            try {
+                val records = withContext(Dispatchers.IO) {
+                    fetchSharedRecords()
+                }
+                adapter.updateRecords(records)
+            } catch (e: Exception) {
+                Toast.makeText(context, "加载失败: ${e.message}", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun fetchSharedRecords(): List<SharedRecord> {
+        val url = URL("${MainActivity.SERVER_URL}/api/shared_records")
+        val connection = url.openConnection() as HttpURLConnection
+        
+        try {
+            connection.requestMethod = "GET"
+            connection.connectTimeout = 10000
+            connection.readTimeout = 10000
+            
+            val responseCode = connection.responseCode
+            if (responseCode == HttpURLConnection.HTTP_OK) {
+                val response = connection.inputStream.bufferedReader().use { it.readText() }
+                val jsonObject = JSONObject(response)
+                val recordsArray = jsonObject.getJSONArray("records")
+                
+                val records = mutableListOf<SharedRecord>()
+                for (i in 0 until recordsArray.length()) {
+                    val record = recordsArray.getJSONObject(i)
+                    records.add(
+                        SharedRecord(
+                            sessionId = record.getString("session_id"),
+                            username = record.optString("username", "匿名"),
+                            filename = record.optString("filename", "未命名"),
+                            timestamp = record.optString("upload_timestamp", "")
+                        )
+                    )
+                }
+                return records
+            }
+        } finally {
+            connection.disconnect()
+        }
+        
+        return emptyList()
+    }
+
+    private fun onRecordClicked(record: SharedRecord) {
+        (activity as? MainActivity)?.loadRecordInPlayer(record.sessionId)
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
+    }
+}
+
+data class SharedRecord(
+    val sessionId: String,
+    val username: String,
+    val filename: String,
+    val timestamp: String
+)

--- a/android/app/src/main/java/com/novelanime/app/ViewPagerAdapter.kt
+++ b/android/app/src/main/java/com/novelanime/app/ViewPagerAdapter.kt
@@ -1,0 +1,18 @@
+package com.novelanime.app
+
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
+import androidx.viewpager2.adapter.FragmentStateAdapter
+
+class ViewPagerAdapter(activity: FragmentActivity) : FragmentStateAdapter(activity) {
+
+    private val fragments = listOf(
+        SquareFragment(),
+        PlayerFragment(),
+        SettingsFragment()
+    )
+
+    override fun getItemCount(): Int = fragments.size
+
+    override fun createFragment(position: Int): Fragment = fragments[position]
+}

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -1,13 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:context=".MainActivity">
 
-    <WebView
-        android:id="@+id/webview"
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tabLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        app:tabTextColor="@android:color/white"
+        app:tabSelectedTextColor="@android:color/white"
+        app:tabIndicatorColor="@android:color/white" />
 
-</RelativeLayout>
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/viewPager"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/fragment_player.xml
+++ b/android/app/src/main/res/layout/fragment_player.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WebView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/playerWebView"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/android/app/src/main/res/layout/fragment_settings.xml
+++ b/android/app/src/main/res/layout/fragment_settings.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="配置"
+            android:textSize="24sp"
+            android:textStyle="bold"
+            android:gravity="center"
+            android:layout_marginBottom="24dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="设置"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:layout_marginBottom="16dp" />
+
+        <Button
+            android:id="@+id/btnSettings"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="打开设置"
+            android:layout_marginBottom="32dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="微信二维码"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:gravity="center"
+            android:layout_marginBottom="16dp" />
+
+        <ImageView
+            android:id="@+id/wechatQRCode"
+            android:layout_width="200dp"
+            android:layout_height="200dp"
+            android:layout_gravity="center"
+            android:scaleType="fitCenter"
+            android:contentDescription="微信群二维码"
+            android:layout_marginBottom="32dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="APK下载二维码"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:gravity="center"
+            android:layout_marginBottom="16dp" />
+
+        <ImageView
+            android:id="@+id/apkQRCode"
+            android:layout_width="200dp"
+            android:layout_height="200dp"
+            android:layout_gravity="center"
+            android:scaleType="fitCenter"
+            android:contentDescription="APK下载二维码" />
+
+    </LinearLayout>
+</ScrollView>

--- a/android/app/src/main/res/layout/fragment_square.xml
+++ b/android/app/src/main/res/layout/fragment_square.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="广布广场"
+        android:textSize="24sp"
+        android:textStyle="bold"
+        android:gravity="center"
+        android:layout_marginBottom="16dp" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</LinearLayout>

--- a/android/app/src/main/res/layout/item_shared_record.xml
+++ b/android/app/src/main/res/layout/item_shared_record.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="4dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/tvFilename"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textSize="16sp"
+            android:textStyle="bold"
+            android:layout_marginBottom="8dp" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <TextView
+                android:id="@+id/tvUsername"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:textSize="14sp"
+                android:textColor="#666" />
+
+            <TextView
+                android:id="@+id/tvTimestamp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="12sp"
+                android:textColor="#999" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION
- 实现3个Tab页: 广布广场/动漫播放/配置
- 广布广场为默认tab,显示随机发布的作品
- 动漫播放页面使用WebView加载播放功能
- 配置页面包含设置按钮、微信二维码和APK二维码
- 使用ViewPager2 + TabLayout实现tab切换
- 新增Fragment: SquareFragment, PlayerFragment, SettingsFragment
- 新增SettingsActivity用于详细设置
- 更新依赖: ViewPager2, RecyclerView, CardView, Coroutines

🤖 Generated with [codeagent](https://github.com/qbox/codeagent)